### PR TITLE
Improve property filter tool.

### DIFF
--- a/moddingSuite/View/Edata/EdataManagerView.xaml
+++ b/moddingSuite/View/Edata/EdataManagerView.xaml
@@ -10,7 +10,7 @@
     xmlns:view="clr-namespace:moddingSuite.View"
     Title="Wargame Modding Suite"
     Width="1367.591"
-    Height="1250.885"
+    Height="729.885"
     Icon="{StaticResource PackageFileIcon}"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">

--- a/moddingSuite/View/Edata/EdataManagerView.xaml
+++ b/moddingSuite/View/Edata/EdataManagerView.xaml
@@ -10,7 +10,7 @@
     xmlns:view="clr-namespace:moddingSuite.View"
     Title="Wargame Modding Suite"
     Width="1367.591"
-    Height="729.885"
+    Height="1250.885"
     Icon="{StaticResource PackageFileIcon}"
     WindowStartupLocation="CenterScreen"
     mc:Ignorable="d">

--- a/moddingSuite/ViewModel/Ndf/NdfClassViewModel.cs
+++ b/moddingSuite/ViewModel/Ndf/NdfClassViewModel.cs
@@ -125,25 +125,39 @@ namespace moddingSuite.ViewModel.Ndf
 
                 if (propVal == null)
                 {
-                    ret = false;
-                    continue;
+                    return false;
                 }
 
-                if (propVal.Value == null)
+                if (propVal.Value == null || propVal.Value.ToString().ToLower().Equals("null"))
                 {
                     if (expr.Value.Length > 0)
-                        ret = false;
-
-                    continue;
+                        return false;
                 }
 
-                if (propVal.Value.ToString().Contains(expr.Value))
-                    continue;
+                int compare = String.Compare(propVal.Value.ToString(), expr.Value);
 
-                return false;
+                if (expr.Discriminator == FilterDiscriminator.Equals)
+                    if (compare == 0)
+                        continue;
+                    else
+                        return false;
+
+                else if (expr.Discriminator == FilterDiscriminator.Smaller)
+                    if (compare < 0)
+                        continue;
+                    else
+                        return false;
+
+                else if (expr.Discriminator == FilterDiscriminator.Greater)
+                    if (compare > 0)
+                        continue;
+                    else 
+                        return false;
+                else
+                    return false;
             }
 
-            return ret;
+            return true;
         }
 
         protected void InstancesCollectionViewCurrentChanged(object sender, EventArgs e)

--- a/moddingSuite/ViewModel/Ndf/NdfClassViewModel.cs
+++ b/moddingSuite/ViewModel/Ndf/NdfClassViewModel.cs
@@ -114,8 +114,6 @@ namespace moddingSuite.ViewModel.Ndf
             if (obj == null)
                 return false;
 
-            bool ret = true;
-
             foreach (PropertyFilterExpression expr in PropertyFilterExpressions)
             {
                 if (expr.PropertyName == null)
@@ -143,13 +141,13 @@ namespace moddingSuite.ViewModel.Ndf
                         return false;
 
                 else if (expr.Discriminator == FilterDiscriminator.Smaller)
-                    if (compare < 0)
+                    if (propVal.Value.ToString().Length < expr.Value.Length || (propVal.Value.ToString().Length == expr.Value.Length && compare < 0))
                         continue;
                     else
                         return false;
 
                 else if (expr.Discriminator == FilterDiscriminator.Greater)
-                    if (compare > 0)
+                    if (propVal.Value.ToString().Length > expr.Value.Length || (propVal.Value.ToString().Length == expr.Value.Length && compare > 0))
                         continue;
                     else 
                         return false;


### PR DESCRIPTION
This isn't a perfect fix for the tool, but it works much better than before.

It treats properties with shorter lengths as smaller and longer lengths as Bigger. If the length is equal, it uses lexicographic (dictionary) ordering. This is the best I could do without going all the way to parsing them out as numbers vs non-numerical values. It works correctly for non-decimal numbers.

Thanks to the modding community!