### PR TITLE
Fix unhandled exception when editing an object reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This software brings modding to R.U.S.E, Wargame: European Escalation, Wargame: 
 System Requirements
 ============
 
-You need to have the .net 4.5 Framework installed you can download it here:
-http://www.microsoft.com/en-us/download/details.aspx?id=30653
+You need to have the .net 4.7.2 Framework installed you can download it here:
+https://dotnet.microsoft.com/download/dotnet-framework/net472
 
 
 License

--- a/moddingSuite/Model/Ndfbin/Types/AllTypes/NdfObjectReference.cs
+++ b/moddingSuite/Model/Ndfbin/Types/AllTypes/NdfObjectReference.cs
@@ -22,7 +22,7 @@ namespace moddingSuite.Model.Ndfbin.Types.AllTypes
         public NdfClass Class
         {
             get { return _class; }
-            protected set
+            set
             {
                 _class = value;
                 OnPropertyChanged("Class");


### PR DESCRIPTION
Editing any object reference in the value editor produces the following exception:

```
System.InvalidOperationException: A TwoWay or OneWayToSource binding cannot work on the read-only property 'Class' of type 'moddingSuite.Model.Ndfbin.Types.AllTypes.NdfObjectReference'.
```

The Class setter is NDfObjectReference is marked protected, which prohibits the data binder from accessing it. Prior to 862514155020e4d5e21b779f08d561410dfcd784 this wasn't a problem, but with the upgrade to .NET 4.7.2, it appears this constraint is now enforced. The fix is to make the setter public.