### PR TITLE
Widestring and objectreference copyandsearchfixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ License
 ============
 
 The Wargame modding suite is released under the MIT license.
+
+
+
+**Simple guide**:
+https://docs.google.com/document/d/1l2vut_I3q-TI-VGy777rl_Fw9RP6Ook9hjOF8qIyZXM/edit?usp=sharing 

--- a/moddingSuite.sln
+++ b/moddingSuite.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31321.278
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33502.453
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "moddingSuite", "moddingSuite\moddingSuite.csproj", "{ED8773BC-C0F3-45E2-A182-07A06260F1F7}"
 EndProject

--- a/moddingSuite/App.xaml
+++ b/moddingSuite/App.xaml
@@ -99,6 +99,9 @@
         <DataTemplate x:Key="GuidEditingTemplate">
             <ValueEditing:GuidEditingTemplate />
         </DataTemplate>
+        <DataTemplate x:Key="WideStringEditingTemplate">
+            <ValueEditing:WideStringEditingTemplate />
+        </DataTemplate>
         <DataTemplate x:Key="BooleanEditingTemplate">
             <ValueEditing:BooleanEditingTemplate />
         </DataTemplate>
@@ -110,7 +113,6 @@
         <DataTemplate x:Key="MapEditingTemplate">
             <ValueEditing:MapEditingTemplate />
         </DataTemplate>
-
 
         <DataTemplate x:Key="StringTableEditingTemplate">
             <ValueEditing:StringTableEditingTemplate />

--- a/moddingSuite/Model/Ndfbin/NdfPropertyValue.cs
+++ b/moddingSuite/Model/Ndfbin/NdfPropertyValue.cs
@@ -180,9 +180,11 @@ namespace moddingSuite.Model.Ndfbin
 
             var newVal = Value.GetBytes();
 
+            if (newVal == null) return;
+
             if (newVal != null && _oldVal != null && Utils.ByteArrayCompare(newVal, _oldVal))
                 return;
-
+            
             ChangeEntryBase change = null;
 
             switch (Value.Type)

--- a/moddingSuite/Model/Ndfbin/Types/AllTypes/NdfObjectReference.cs
+++ b/moddingSuite/Model/Ndfbin/Types/AllTypes/NdfObjectReference.cs
@@ -25,7 +25,11 @@ namespace moddingSuite.Model.Ndfbin.Types.AllTypes
             set
             {
                 _class = value;
-                OnPropertyChanged("Class");
+
+                if (value != null)
+                {
+                    OnPropertyChanged("Class");
+                }
             }
         }
 
@@ -70,6 +74,8 @@ namespace moddingSuite.Model.Ndfbin.Types.AllTypes
         public override byte[] GetBytes()
         {
             var refereceData = new List<byte>();
+
+            if (Class == null) { return null; }
 
             refereceData.AddRange(BitConverter.GetBytes(InstanceId));
 

--- a/moddingSuite/View/Extension/EditingControlDataTemplateSelector.cs
+++ b/moddingSuite/View/Extension/EditingControlDataTemplateSelector.cs
@@ -41,10 +41,10 @@ namespace moddingSuite.View.Extension
 
                 case NdfType.Color32:
                     return element.FindResource("ColorPickerEditingTemplate") as DataTemplate;
-
+                case NdfType.WideString:
+                    return element.FindResource("WideStringEditingTemplate") as DataTemplate;
                 case NdfType.Vector:
                     return element.FindResource("VectorEditingTemplate") as DataTemplate;
-                    
 
                 case NdfType.Map:
                     return element.FindResource("MapEditingTemplate") as DataTemplate;

--- a/moddingSuite/View/Ndfbin/NdfbinView.xaml
+++ b/moddingSuite/View/Ndfbin/NdfbinView.xaml
@@ -126,7 +126,8 @@
                                     Width="150"
                                     Margin="5"
                                     VerticalAlignment="Top"
-                                    Text="{Binding Path=ClassesFilterExpression, UpdateSourceTrigger=PropertyChanged}" />
+                                    Text="{Binding Path=ClassesFilterExpression, UpdateSourceTrigger=PropertyChanged}"
+                                    TextChanged="TextBox_TextChanged"/>
 
                                 <Button Command="{Binding MakeTopObjectCommand}" ToolTip="Make top object">
                                     <Image SnapsToDevicePixels="True" Source="{StaticResource ImportIcon}" />
@@ -181,7 +182,8 @@
                                 IsSynchronizedWithCurrentItem="True"
                                 ItemsSource="{Binding Path=ClassesCollectionView}"
                                 SelectionMode="Extended"
-                                SelectionUnit="FullRow">
+                                SelectionUnit="FullRow"
+                                SelectionChanged="classGrid_SelectionChanged">
                                 <DataGrid.Columns>
                                     <DataGridTextColumn
                                         Width="40"

--- a/moddingSuite/View/Ndfbin/NdfbinView.xaml
+++ b/moddingSuite/View/Ndfbin/NdfbinView.xaml
@@ -126,8 +126,11 @@
                                     Width="150"
                                     Margin="5"
                                     VerticalAlignment="Top"
-                                    Text="{Binding Path=ClassesFilterExpression, UpdateSourceTrigger=PropertyChanged}"
-                                    TextChanged="TextBox_TextChanged"/>
+                                    TextChanged="TextBox_TextChanged">
+                                    <TextBox.Text>
+                                        <Binding Path="ClassesFilterExpression" UpdateSourceTrigger="PropertyChanged" Delay="500"></Binding>
+                                    </TextBox.Text>
+                                </TextBox>
 
                                 <Button Command="{Binding MakeTopObjectCommand}" ToolTip="Make top object">
                                     <Image SnapsToDevicePixels="True" Source="{StaticResource ImportIcon}" />

--- a/moddingSuite/View/Ndfbin/NdfbinView.xaml.cs
+++ b/moddingSuite/View/Ndfbin/NdfbinView.xaml.cs
@@ -11,5 +11,31 @@ namespace moddingSuite.View.Ndfbin
         {
             InitializeComponent();
         }
+
+        private void TextBox_TextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
+        {
+            //selects the top class if there are classes to select to avoid having nothing selected
+            if (classGrid.Items.Count > 0) 
+            {
+                classGrid.SelectedItem = classGrid.Items[0];
+            }
+            SetInstanceGridItem();
+        }
+
+        private void classGrid_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            SetInstanceGridItem();
+        }
+        private void SetInstanceGridItem()
+        {
+            // scrolls to currently selected instance
+            if (instanceGrid.Items.Count == 0)
+            {
+                return;
+            }
+            instanceGrid.ScrollIntoView(instanceGrid.Items[instanceGrid.Items.Count - 1]);
+            instanceGrid.UpdateLayout();
+            instanceGrid.ScrollIntoView(instanceGrid.SelectedItem);
+        }
     }
 }

--- a/moddingSuite/View/Ndfbin/NdfbinView.xaml.cs
+++ b/moddingSuite/View/Ndfbin/NdfbinView.xaml.cs
@@ -14,12 +14,21 @@ namespace moddingSuite.View.Ndfbin
 
         private void TextBox_TextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
         {
-            //selects the top class if there are classes to select to avoid having nothing selected
-            if (classGrid.Items.Count > 0) 
+
+            try
             {
-                classGrid.SelectedItem = classGrid.Items[0];
+                //selects the top class if there are classes to select to avoid having nothing selected
+                if (classGrid.Items.Count > 0)
+                {
+                    classGrid.SelectedItem = classGrid.Items[0];
+                }
+                SetInstanceGridItem();
             }
-            SetInstanceGridItem();
+            catch (System.Exception)
+            {
+
+                throw new System.Exception("fout in roemers code");
+            }
         }
 
         private void classGrid_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
@@ -28,14 +37,22 @@ namespace moddingSuite.View.Ndfbin
         }
         private void SetInstanceGridItem()
         {
-            // scrolls to currently selected instance
-            if (instanceGrid.Items.Count == 0)
+            try
             {
-                return;
+                // scrolls to currently selected instance
+                if (instanceGrid.Items == null || instanceGrid.Items.Count == 0)
+                {
+                    return;
+                }
+                instanceGrid.ScrollIntoView(instanceGrid.Items[instanceGrid.Items.Count - 1]);
+                instanceGrid.UpdateLayout();
+                instanceGrid.ScrollIntoView(instanceGrid.SelectedItem);
             }
-            instanceGrid.ScrollIntoView(instanceGrid.Items[instanceGrid.Items.Count - 1]);
-            instanceGrid.UpdateLayout();
-            instanceGrid.ScrollIntoView(instanceGrid.SelectedItem);
+            catch (System.Exception)
+            {
+
+                throw new System.Exception("fout in roemers code 2");
+            }
         }
     }
 }

--- a/moddingSuite/View/Ndfbin/ValueEditing/WideStringEditingTemplate.xaml
+++ b/moddingSuite/View/Ndfbin/ValueEditing/WideStringEditingTemplate.xaml
@@ -1,0 +1,11 @@
+﻿<UserControl x:Class="moddingSuite.View.Ndfbin.ValueEditing.WideStringEditingTemplate"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:Extension1="clr-namespace:moddingSuite.View.Extension" mc:Ignorable="d" 
+             d:DesignHeight="300" d:DesignWidth="300">
+    <Grid>
+        <TextBox Text="{Binding Path=Value.Value}" />
+    </Grid>
+</UserControl>

--- a/moddingSuite/View/Ndfbin/ValueEditing/WideStringEditingTemplate.xaml.cs
+++ b/moddingSuite/View/Ndfbin/ValueEditing/WideStringEditingTemplate.xaml.cs
@@ -1,0 +1,15 @@
+﻿using System.Windows.Controls;
+
+namespace moddingSuite.View.Ndfbin.ValueEditing
+{
+    /// <summary>
+    /// Interaction logic for WideStringEditingTemplate.xaml
+    /// </summary>
+    public partial class WideStringEditingTemplate : UserControl
+    {
+        public WideStringEditingTemplate()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/moddingSuite/View/Ndfbin/Viewer/InstanceView.xaml
+++ b/moddingSuite/View/Ndfbin/Viewer/InstanceView.xaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-             xmlns:Viewer="clr-namespace:moddingSuite.View.Ndfbin.Viewer" mc:Ignorable="d" d:DesignHeight="365" d:DesignWidth="820">
+             xmlns:Viewer="clr-namespace:moddingSuite.View.Ndfbin.Viewer" mc:Ignorable="d" d:DesignHeight="450" d:DesignWidth="820">
     <Grid Margin="0">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />

--- a/moddingSuite/View/Ndfbin/Viewer/InstanceWindowView.xaml
+++ b/moddingSuite/View/Ndfbin/Viewer/InstanceWindowView.xaml
@@ -1,7 +1,7 @@
 ﻿<Window x:Class="moddingSuite.View.Ndfbin.Viewer.InstanceWindowView"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:Viewer="clr-namespace:moddingSuite.View.Ndfbin.Viewer" Title="{Binding Path=Name}" Height="300" Width="800" Icon="{StaticResource ScriptIcon}">
+        xmlns:Viewer="clr-namespace:moddingSuite.View.Ndfbin.Viewer" Title="{Binding Path=Name}" Height="400" Width="800" Icon="{StaticResource ScriptIcon}">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />

--- a/moddingSuite/ViewModel/Filter/FilterDiscriminator.cs
+++ b/moddingSuite/ViewModel/Filter/FilterDiscriminator.cs
@@ -5,6 +5,7 @@
         Equals,
         Smaller,
         Greater,
-        Contains
+        Contains,
+        Excludes
     }
 }

--- a/moddingSuite/ViewModel/Ndf/ListEditorViewModel.cs
+++ b/moddingSuite/ViewModel/Ndf/ListEditorViewModel.cs
@@ -95,24 +95,24 @@ namespace moddingSuite.ViewModel.Ndf
 
             if (cv == null)
                 return;
+            
+            if (cv.CurrentItem == null)
+                return;
 
             NdfType type =
                 Value.GroupBy(x => x.Value.Type).OrderByDescending(gp => gp.Count()).Select(x => x.First().Value.Type).
                     Single();
+            var val = cv.CurrentItem as CollectionItemValueHolder;
+            
+            //old method
+            //var wrapper =
+               // new CollectionItemValueHolder(NdfTypeManager.GetValue(new byte[NdfTypeManager.SizeofType(type)], type, NdfbinManager), NdfbinManager);
 
             var wrapper =
-                new CollectionItemValueHolder(NdfTypeManager.GetValue(new byte[NdfTypeManager.SizeofType(type)], type, NdfbinManager), NdfbinManager);
+                new CollectionItemValueHolder(val.Value, NdfbinManager);
 
             if (IsInsertMode)
             {
-                if (cv.CurrentItem == null)
-                    return;
-
-                var val = cv.CurrentItem as CollectionItemValueHolder;
-
-                if (val == null)
-                    return;
-
                 Value.Insert(cv.CurrentPosition + 1, wrapper);
             }
             else

--- a/moddingSuite/ViewModel/Ndf/NdfClassViewModel.cs
+++ b/moddingSuite/ViewModel/Ndf/NdfClassViewModel.cs
@@ -166,13 +166,19 @@ namespace moddingSuite.ViewModel.Ndf
                 int compare = String.Compare(propVal.Value.ToString(), expr.Value);
 
                 if (expr.Discriminator == FilterDiscriminator.Equals)
-                    if (compare == 0)
-                        if (expr.Discriminator == FilterDiscriminator.Excludes)
-                            return false;
-                            else   
-                                continue;
+                {
+                    if (compare == 0)//means equal
+                    {
+                        continue;
+                    }                
                     else
                         return false;
+                }
+                else if (expr.Discriminator == FilterDiscriminator.Excludes)
+                    if (propVal.Value.ToString().Contains(expr.Value))
+                        return false; 
+                    else
+                        continue;
 
                 else if (expr.Discriminator == FilterDiscriminator.Smaller)
                     if (propVal.Value.ToString().Length < expr.Value.Length || (propVal.Value.ToString().Length == expr.Value.Length && compare < 0))

--- a/moddingSuite/ViewModel/Ndf/NdfClassViewModel.cs
+++ b/moddingSuite/ViewModel/Ndf/NdfClassViewModel.cs
@@ -93,12 +93,14 @@ namespace moddingSuite.ViewModel.Ndf
         /// <summary>
         /// Allows scripts to append a new instance.
         /// </summary>
-        public void AddInstance(bool isTopLevelInstance)
+        public NdfObjectViewModel AddInstance(bool isTopLevelInstance)
         {
             NdfObject inst = Object.Manager.CreateInstanceOf(Object, isTopLevelInstance);
-
             Object.Instances.Add(inst);
-            Instances.Add(new NdfObjectViewModel(inst, ParentVm));
+
+            var instModel = new NdfObjectViewModel(inst, ParentVm);
+            Instances.Add(instModel);
+            return instModel;
         }
 
         /// <summary>
@@ -149,7 +151,10 @@ namespace moddingSuite.ViewModel.Ndf
 
                 if (propVal == null)
                 {
-                    return false;
+                    if (expr.Value.Equals("\\0"))
+                        continue;
+                    else
+                        return false;
                 }
 
                 if (propVal.Value == null || propVal.Value.ToString().ToLower().Equals("null"))
@@ -162,7 +167,10 @@ namespace moddingSuite.ViewModel.Ndf
 
                 if (expr.Discriminator == FilterDiscriminator.Equals)
                     if (compare == 0)
-                        continue;
+                        if (expr.Discriminator == FilterDiscriminator.Excludes)
+                            return false;
+                            else   
+                                continue;
                     else
                         return false;
 

--- a/moddingSuite/ViewModel/Ndf/NdfClassViewModel.cs
+++ b/moddingSuite/ViewModel/Ndf/NdfClassViewModel.cs
@@ -7,6 +7,7 @@ using System.Windows;
 using System.Windows.Data;
 using System.Windows.Input;
 using moddingSuite.Model.Ndfbin;
+using moddingSuite.Model.Ndfbin.Types;
 using moddingSuite.ViewModel.Base;
 using moddingSuite.ViewModel.Filter;
 
@@ -148,6 +149,12 @@ namespace moddingSuite.ViewModel.Ndf
                     continue;
 
                 NdfPropertyValue propVal = obj.PropertyValues.SingleOrDefault(x => x.Property.Name == expr.PropertyName);
+                if (string.IsNullOrEmpty(expr.Value))
+                    //expr.Value is the thing on right side of the little filter box
+                    continue;
+
+
+
 
                 if (propVal == null)
                 {
@@ -157,10 +164,20 @@ namespace moddingSuite.ViewModel.Ndf
                         return false;
                 }
 
+                if (expr.Discriminator == FilterDiscriminator.Equals)
+                {
+                    if ((propVal.Value == null) && expr.Value.Equals("null"))
+                    //filter by null
+                    {
+                        continue;
+                    }
+                }
+
+                //propVal.Value.ToString() is the actual value of the property for an instance
                 if (propVal.Value == null || propVal.Value.ToString().ToLower().Equals("null"))
                 {
-                    if (expr.Value.Length > 0)
-                        return false;
+                    //if (expr.Value.Length > 0)
+                        //return false; this line stop filter by null from working
                 }
 
                 int compare = String.Compare(propVal.Value.ToString(), expr.Value);
@@ -170,7 +187,12 @@ namespace moddingSuite.ViewModel.Ndf
                     if (compare == 0)//means equal
                     {
                         continue;
-                    }                
+                    } 
+                    else if ((propVal.Value == null  )&& expr.Value.Equals("null"))
+                        //filter by null
+                    {
+                        continue;
+                    }
                     else
                         return false;
                 }

--- a/moddingSuite/ViewModel/Ndf/NdfEditorMainViewModel.cs
+++ b/moddingSuite/ViewModel/Ndf/NdfEditorMainViewModel.cs
@@ -154,7 +154,7 @@ namespace moddingSuite.ViewModel.Ndf
         private NdfObject CopyInstance(NdfObject instToCopy)
         {
             NdfObject newInst = instToCopy.Class.Manager.CreateInstanceOf(instToCopy.Class, instToCopy.IsTopObject);
-            
+
             _copyInstanceResults.Add(newInst);
 
             foreach (var propertyValue in instToCopy.PropertyValues)
@@ -498,12 +498,25 @@ namespace moddingSuite.ViewModel.Ndf
             string[] parts = ClassesFilterExpression.Split(new[] { ":" }, StringSplitOptions.RemoveEmptyEntries);
 
             int cls;
-
+            
             if (parts.Length > 1 && Int32.TryParse(parts[0], out cls) && (clas.Id == cls || clas.Name == parts[0]))
             {
+                // filters like this 26:2556 with Classnumber:Instancenumber, could be removed?
                 int inst;
                 if (Int32.TryParse(parts[1], out inst))
                 {
+                    NdfObjectViewModel instObj = clas.Instances.SingleOrDefault(x => x.Id == inst);
+
+                    if (instObj != null)
+                        clas.InstancesCollectionView.MoveCurrentTo(instObj);
+                }
+            }
+            else
+            {
+                int inst;
+                if (Int32.TryParse(parts[0], out inst))
+                {
+                    // selects instance searched for added by Reros
                     NdfObjectViewModel instObj = clas.Instances.SingleOrDefault(x => x.Id == inst);
 
                     if (instObj != null)
@@ -586,13 +599,14 @@ namespace moddingSuite.ViewModel.Ndf
             var vm = new NdfClassViewModel(cls.Object.Class, this);
             NdfObjectViewModel inst = vm.Instances.SingleOrDefault(x => x.Id == cls.Id);
             ViewModelBase baseViewModel;
-            switch (cls.Object.Class.Name) {
+            switch (cls.Object.Class.Name)
+            {
                 case "TGameplayArmeArmureContainer":
                 case "TGameplayDamageResistanceContainer":
                     baseViewModel = new ArmourDamageViewModel(inst.Object, this);
                     break;
                 default:
-                     if (inst == null)
+                    if (inst == null)
                         return;
                     vm.InstancesCollectionView.MoveCurrentTo(inst);
                     baseViewModel = vm;

--- a/moddingSuite/ViewModel/Ndf/NdfEditorMainViewModel.cs
+++ b/moddingSuite/ViewModel/Ndf/NdfEditorMainViewModel.cs
@@ -192,12 +192,27 @@ namespace moddingSuite.ViewModel.Ndf
 
                     break;
                 case NdfType.List:
-                case NdfType.MapList:
                     var copiedItems = new List<CollectionItemValueHolder>();
                     var collection = toCopy.Value as NdfCollection;
                     if (collection != null)
+                    {
                         copiedItems.AddRange(collection.Select(entry => new CollectionItemValueHolder(GetCopiedValue(entry), toCopy.Manager)));
+                    }
+
                     copiedValue = new NdfCollection(copiedItems);
+                    break;
+                case NdfType.MapList:
+                    // creates Maplist type copy as NdfMaplist:Collection, written by Reros
+                    var copiedMapItems = new NdfMapList();
+                    var collectionMap = toCopy.Value as NdfCollection;
+                    if (collectionMap != null)
+                    {
+                        foreach (var item in collectionMap)
+                        {
+                            copiedMapItems.Add(new CollectionItemValueHolder(GetCopiedValue(item), toCopy.Manager));
+                        }
+                    }
+                    copiedValue = copiedMapItems;
                     break;
 
                 case NdfType.Map:

--- a/moddingSuite/ViewModel/Ndf/NdfObjectViewModel.cs
+++ b/moddingSuite/ViewModel/Ndf/NdfObjectViewModel.cs
@@ -5,6 +5,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Input;
+using IronPython.Runtime.Operations;
 using moddingSuite.Model.Ndfbin;
 using moddingSuite.Model.Ndfbin.Types;
 using moddingSuite.Model.Ndfbin.Types.AllTypes;
@@ -139,14 +140,20 @@ namespace moddingSuite.ViewModel.Ndf
         private void CopyToInstancesExecute(object obj)
         {
             var cv = CollectionViewSource.GetDefaultView(PropertyValues);
+            var result = MessageBox.Show("Do you want to copy this instance value to ALL other instances? If unsure, press no", "Confirmation",
+                MessageBoxButton.YesNo, MessageBoxImage.Question,defaultResult: MessageBoxResult.No);
 
-            var item = cv.CurrentItem as NdfPropertyValue;
-            foreach (var instance in item.Instance.Class.Instances)
+            if (result == MessageBoxResult.Yes)
             {
-                var property = instance.PropertyValues.First(x => x.Property == item.Property);
-                property.BeginEdit();
-                property.Value = item.Value;
-                property.EndEdit();
+                var item = cv.CurrentItem as NdfPropertyValue;
+
+                foreach (var instance in item.Instance.Class.Instances)
+                {
+                    var property = instance.PropertyValues.First(x => x.Property == item.Property);
+                    property.BeginEdit();
+                    property.Value = item.Value;
+                    property.EndEdit();
+                }
             }
         }
 


### PR DESCRIPTION
Added Widestring edit

Objectrefence copy now copies class
Making typo in objectreference search now no longer throws exception, and can research as long as you dont click away while an incorrect class is in